### PR TITLE
feat: connect CLI to backend /ask endpoint

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -421,6 +421,26 @@ export class GraphynAPIClient {
       return response.data;
     });
   }
+
+  /**
+   * Send a request to the /ask endpoint for AI agent orchestration
+   */
+  async ask(request: any): Promise<any> {
+    return this.withRetry(async () => {
+      const response = await this.client.post('/api/ask', request);
+      return response.data;
+    });
+  }
+
+  /**
+   * Generic post method for API requests
+   */
+  async post<T>(path: string, data: any): Promise<T> {
+    return this.withRetry(async () => {
+      const response = await this.client.post<T>(path, data);
+      return response.data;
+    });
+  }
 }
 
 // Export a singleton instance

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -3,7 +3,6 @@ import { OAuthManager } from './auth/oauth.js';
 import { analyzeRepository } from './commands/analyze.js';
 import { doctor } from './commands/doctor.js';
 import { checkSystemRequirements } from './utils/system-check.js';
-import { GraphynAPIClient } from './api-client.js';
 import { config } from './config.js';
 import { AskService } from './services/ask-service.js';
 import chalk from 'chalk';
@@ -197,13 +196,8 @@ Examples:
       console.log(colors.success('\n✓ Re-authentication successful!\n'));
     }
     
-    // Step 3: Initialize API client with token
-    const apiClient = new GraphynAPIClient(config.apiBaseUrl);
-    apiClient.setToken(token);
-    await apiClient.initialize();
-    
-    // Step 4: Process query with Ask service
-    const askService = new AskService(apiClient);
+    // Step 3: Process query with Ask service
+    const askService = new AskService();
     const response = await askService.processQuery(userMessage, process.cwd());
     
     // Step 5: Launch agents (if in interactive mode)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -90,15 +90,15 @@ export class InitCommand {
     try {
       const requirements = await checkSystemRequirements();
       
-      if (requirements.allPassed) {
+      if (requirements.canProceed) {
         spinner.succeed('System requirements checked');
       } else {
         spinner.warn('Some system requirements are missing');
         
         const missing = [];
-        if (!requirements.node) missing.push('Node.js');
-        if (!requirements.git) missing.push('Git');
-        if (!requirements.tmux) missing.push('tmux (optional but recommended)');
+        if (requirements.needsClaudeCode) missing.push('Claude Code');
+        if (requirements.needsTmux) missing.push('tmux (optional but recommended)');
+        if (requirements.needsFigmaMCP) missing.push('Figma MCP (optional)');
         
         if (missing.length > 0) {
           console.log(colors.warning(`\n⚠️  Missing: ${missing.join(', ')}`));

--- a/src/services/ask-service.ts
+++ b/src/services/ask-service.ts
@@ -1,4 +1,4 @@
-import { GraphynAPIClient } from '../api-client.js';
+import { apiClient } from '../api/client.js';
 import { TMUXCockpitOrchestrator } from '../utils/tmux-cockpit-orchestrator.js';
 import { RepositoryContextExtractor, ExtractedContext } from './repository-context-extractor.js';
 import { RepositoryAnalyzerService } from './repository-analyzer.js';
@@ -45,7 +45,7 @@ export class AskService {
   private agentLauncher: ClaudeAgentLauncher;
   private cockpit: TMUXCockpitOrchestrator;
 
-  constructor(private apiClient: GraphynAPIClient) {
+  constructor() {
     const analyzer = new RepositoryAnalyzerService();
     this.contextExtractor = new RepositoryContextExtractor(analyzer);
     this.agentLauncher = new ClaudeAgentLauncher();
@@ -79,14 +79,8 @@ export class AskService {
   }
 
   private async sendAskRequest(request: AskRequest): Promise<AskResponse> {
-    try {
-      const response = await this.apiClient.post<AskResponse>('/api/ask', request);
-      return response;
-    } catch (error) {
-      // If backend endpoint doesn't exist yet, return mock response
-      console.log(chalk.yellow('⚠️  Using mock response (backend endpoint not implemented)'));
-      return this.getMockResponse(request);
-    }
+    const response = await apiClient.post<AskResponse>('/api/ask', request);
+    return response;
   }
 
   private displayOrchestrationPlan(response: AskResponse): void {


### PR DESCRIPTION
## Summary
- Connected the CLI to use the real backend /ask endpoint
- Removed mock response fallback from ask-service
- Consolidated API client usage to use singleton pattern

## Changes
- Added `ask()` and generic `post()` methods to GraphynAPIClient
- Updated AskService to use real backend endpoint without fallback
- Updated all services to use singleton apiClient from api/client.ts
- Fixed TypeScript compilation errors across multiple files
- Removed dependency on old GraphynAPIClient implementation

## Testing
- Build passes successfully with `npm run build`
- All TypeScript errors resolved
- Services now properly use authenticated API client

Closes #93